### PR TITLE
match all URLs for puzzles, analysis, and live games

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Speak to Chess.com (Standard Notation)",
-  "description": "Play hands-free by dictating moves in standard chess notation (e.g. \"Queen D4\" or \"Castle King-side\").",
-  "version": "1.0.0",
+  "description": "Move your pieces with voice commands (like \"Queen D4\"). Play hands-free using standard chess notation.",
+  "version": "1.1.0",
   "action": {
     "default_icon": {
       "16": "./images/icons/icon16.png",
@@ -19,10 +19,19 @@
     { 
       "js": ["./scripts/script.js"],
       "matches": [
+        "https://www.chess.com/daily-chess-puzzle",
+        "https://www.chess.com/daily-chess-puzzle/*",
+        "https://www.chess.com/puzzles/rated",
+        "https://www.chess.com/play/online/new",
+        "https://www.chess.com/play/online/new?action=createLiveChallenge*",
         "https://www.chess.com/game/live/*",
         "https://www.chess.com/game/daily/*",
         "https://www.chess.com/analysis/game/live/*",
-        "https://www.chess.com/analysis/game/daily/*"
+        "https://www.chess.com/analysis/game/daily/*",
+        "https://www.chess.com/analysis/game/pgn/*",
+        "https://www.chess.com/analysis",
+        "https://www.chess.com/analysis?*",
+        "https://www.chess.com/analysis&*"
       ]
     }
   ]


### PR DESCRIPTION
## Fixes
- Previously, extension did not always appear when starting a game. Now, the extension appears for all URLs for live games and analysis.
- The extension also appears for puzzles now.

This PR also adjusts extension description and bumps to v1.1.0